### PR TITLE
Fix missing routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,6 +104,76 @@ def filter_images(min_width, min_height, max_width, max_height):
 def home():
     return render_template('index.html')
 
+@app.route('/scrape', methods=['POST'])
+def scrape():
+    url = request.form['url']
+    min_width = int(request.form['min_width'])
+    min_height = int(request.form['min_height'])
+    max_width = int(request.form['max_width'])
+    max_height = int(request.form['max_height'])
+    per_page = int(request.form['per_page'])
+    threading.Thread(
+        target=run_scraper,
+        args=(url, min_width, min_height, max_width, max_height),
+        daemon=True,
+    ).start()
+    return redirect(url_for('loading', per_page=per_page))
+
+
+@app.route('/loading')
+def loading():
+    per_page = request.args.get('per_page', 20)
+    return render_template('loading.html', per_page=per_page)
+
+
+@app.route('/progress')
+def get_progress():
+    return jsonify(progress)
+
+
+@app.route('/gallery')
+def gallery():
+    files = []
+    for root, _, filenames in os.walk(DOWNLOAD_DIR):
+        for name in filenames:
+            files.append(os.path.relpath(os.path.join(root, name), DOWNLOAD_DIR))
+    if not files:
+        return "No images found.<br><a href='/'>&larr; Go back</a>"
+    page = int(request.args.get('page', 1))
+    per_page = int(request.args.get('per_page', 20))
+    total_pages = max(1, math.ceil(len(files) / per_page))
+    start = (page - 1) * per_page
+    end = start + per_page
+    files_to_show = files[start:end]
+    return render_template(
+        'gallery.html',
+        files=files_to_show,
+        page=page,
+        per_page=per_page,
+        total_pages=total_pages,
+    )
+
+
+@app.route('/img/<path:filename>')
+def img(filename):
+    return send_from_directory(DOWNLOAD_DIR, filename)
+
+
+@app.route('/download')
+def download_zip():
+    mem_zip = io.BytesIO()
+    with zipfile.ZipFile(mem_zip, 'w') as zf:
+        for filename in os.listdir(DOWNLOAD_DIR):
+            filepath = os.path.join(DOWNLOAD_DIR, filename)
+            zf.write(filepath, arcname=filename)
+    mem_zip.seek(0)
+    return send_file(
+        mem_zip,
+        mimetype='application/zip',
+        as_attachment=True,
+        download_name='images.zip',
+    )
+
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8080)


### PR DESCRIPTION
## Summary
- restore `/scrape`, `/progress`, `/gallery` and other routes

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68554a5f8010832fbe0856f0694480be